### PR TITLE
feat: Add lint.yml Github Workflow for GolangCI Lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,8 +7,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
-      - uses: actions/checkout@v3
       - uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: Lint
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+      - uses: actions/checkout@v3
+      - uses: golangci/golangci-lint-action@v3

--- a/graceful/graceful.go
+++ b/graceful/graceful.go
@@ -31,7 +31,9 @@ func Run(service Graceful) {
 	// terminate your environment gracefully before leaving main function
 	defer func() {
 		log.Info().Msg("stopping server")
-		service.GracefulStop()
+		if err := service.GracefulStop(); err != nil {
+			log.Error().Err(err).Msg("graceful stop failed")
+		}
 	}()
 
 	// block until either OS signal, or server fatal error


### PR DESCRIPTION
This commit adds the .github/workflows/lint.yml file that includes a job for linting code utilizing golangci/golangci-lint-action@v3. The job only runs on pull_request. To accomplish linting, the action-setup-go@v4 and actions/checkout@v3 actions are used.