### PR TITLE
refactor: update import paths to match repo rename

### DIFF
--- a/dapr/service/grpc/health_check.go
+++ b/dapr/service/grpc/health_check.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	pb "github.com/dapr/go-sdk/dapr/proto/runtime/v1"
-	"github.com/releaseband/go-grpc-tools/dapr/service/common"
+	"github.com/releaseband/go-micro-tools/dapr/service/common"
 
 	"google.golang.org/protobuf/types/known/emptypb"
 )

--- a/dapr/service/grpc/service.go
+++ b/dapr/service/grpc/service.go
@@ -9,7 +9,7 @@ import (
 	pb "github.com/dapr/go-sdk/dapr/proto/runtime/v1"
 	"google.golang.org/grpc"
 
-	"github.com/releaseband/go-grpc-tools/dapr/service/common"
+	"github.com/releaseband/go-micro-tools/dapr/service/common"
 )
 
 // NewService creates new Service.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/releaseband/go-grpc-tools
+module github.com/releaseband/go-micro-tools
 
 go 1.20
 

--- a/grpc/interceptor/client/client.go
+++ b/grpc/interceptor/client/client.go
@@ -3,7 +3,7 @@ package client
 import (
 	"context"
 
-	"github.com/releaseband/go-grpc-tools/trace"
+	"github.com/releaseband/go-micro-tools/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )

--- a/grpc/interceptor/server/server.go
+++ b/grpc/interceptor/server/server.go
@@ -3,8 +3,8 @@ package server
 import (
 	"context"
 
-	"github.com/releaseband/go-grpc-tools/trace"
-	"github.com/releaseband/go-grpc-tools/zerolog"
+	"github.com/releaseband/go-micro-tools/trace"
+	"github.com/releaseband/go-micro-tools/zerolog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -3,7 +3,7 @@ package trace
 import (
 	"context"
 
-	"github.com/releaseband/go-grpc-tools/trace/utils"
+	"github.com/releaseband/go-micro-tools/trace/utils"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/zerolog/zerolog.go
+++ b/zerolog/zerolog.go
@@ -3,7 +3,7 @@ package zerolog
 import (
 	"context"
 
-	"github.com/releaseband/go-grpc-tools/trace"
+	"github.com/releaseband/go-micro-tools/trace"
 	"github.com/rs/zerolog/log"
 )
 


### PR DESCRIPTION
This commit renames the import paths in multiple files to match the new repository name. Updated paths include `go.mod`, `grpc/interceptor` files, `trace` files, and `dapr/service/grpc` files.